### PR TITLE
Update the template with changes for the ci user

### DIFF
--- a/test/README.MD
+++ b/test/README.MD
@@ -24,12 +24,23 @@ aws-vault exec mod -- terraform init
 aws-vault exec mod -- terraform workspace select testing-test
 ```
 
-Run the tests from within the `test` directory
+Run the tests from within the `test` directory using the `testing-ci` user credentials.
+
+Get the crededtials from secrets manager using the helper script in the modernisation-platform main repo.
 
 ```
-cd ../
+cd modernisation-platform/scripts/internal/
+aws-vault exec mod -- go run get_testing_creds.go
+```
+
+Copy the credentials from the output of the script and paste them into the terminal from which you will run the tests.
+
+Next go into the testing folder and run the tests.
+
+```
+cd test
 go mod download
-aws-vault exec mod -- go test -v
+go test -v
 ```
 
 Upon successful run, you should see an output similar to the below

--- a/test/unit-test/providers.tf
+++ b/test/unit-test/providers.tf
@@ -6,9 +6,9 @@ provider "aws" {
   }
 }
 
-# AWS provider for the Modernisation Platform, to get things from there if required
+# AWS provider for the testing-ci user (testing-test account), to get things from there if required
 provider "aws" {
-  alias                  = "modernisation-platform"
+  alias                  = "testing-ci-user"
   region                 = "eu-west-2"
   skip_get_ec2_platforms = true
 }

--- a/test/unit-test/secrets.tf
+++ b/test/unit-test/secrets.tf
@@ -1,11 +1,16 @@
-# Get secret by name for environment management
+# Get secret by arn for environment management
+data "aws_ssm_parameter" "environment_management_arn" {
+  provider = aws.testing-ci-user
+  name     = "environment_management_arn"
+}
+
 data "aws_secretsmanager_secret" "environment_management" {
-  provider = aws.modernisation-platform
-  name     = "environment_management"
+  provider = aws.testing-ci-user
+  arn      = data.aws_ssm_parameter.environment_management_arn.value
 }
 
 # Get latest secret value with ID from above. This secret stores account IDs for the Modernisation Platform sub-accounts
 data "aws_secretsmanager_secret_version" "environment_management" {
-  provider  = aws.modernisation-platform
+  provider  = aws.testing-ci-user
   secret_id = data.aws_secretsmanager_secret.environment_management.id
 }


### PR DESCRIPTION
The new testing-ci user in the testing-test account requires slightly
different providers and secrets.

Also updated readme on running locally with the user creds.