### PR TITLE
Explicitly set the terraform workspace in go test code

### DIFF
--- a/test/module_test.go
+++ b/test/module_test.go
@@ -16,7 +16,10 @@ func TestModule(t *testing.T) {
 
 	defer terraform.Destroy(t, terraformOptions)
 
-	terraform.InitAndApply(t, terraformOptions)
+	terraform.Init(t, terraformOptions)
+	terraform.WorkspaceSelectOrNew(t, terraformOptions, "testing-test")
+
+	terraform.Apply(t, terraformOptions)
 
 	exampleName := terraform.Output(t, terraformOptions, "example_name")
 


### PR DESCRIPTION
Relevant issue: https://github.com/ministryofjustice/modernisation-platform/issues/2647

The terratest workflow already explicitly selects the workspace, and the README specifies that you need to select a workspace before running the tests locally, however, since the consequences of running tests without selecting a workspace first are fairly dire, the go code has been modified to explicitly do it within the test.