### PR TITLE
Fix code scanning

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Init TFLint
         run: tflint --init
       - name: Run TFLint
-        run: tflint --format sarif > tflint.sarif
+        run: |
+          tflint --format sarif > tflint.sarif
       - name: Upload SARIF file
         uses: >-
           github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Init TFLint
         run: tflint --init
       - name: Run TFLint
-        run: tflint --format sarif
+        run: tflint --format sarif --force
       - name: Write output to file
         run: echo "${{ steps.tflint.outputs.stdout }}" > tflint.sarif
       - name: Upload SARIF file

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -2,7 +2,7 @@ name: Secure Code Analysis
 on:
   workflow_dispatch: null
   schedule:
-    cron: '35 1 * * 1'
+    - cron: '35 1 * * 1'
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -33,9 +33,7 @@ jobs:
       - name: Init TFLint
         run: tflint --init
       - name: Run TFLint
-        run: tflint --format sarif --force
-      - name: Write output to file
-        run: echo "${{ steps.tflint.outputs.stdout }}" > tflint.sarif
+        run: tflint --format sarif --force > tflint.sarif
       - name: Upload SARIF file
         uses: >-
           github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -1,8 +1,7 @@
 name: Secure Code Analysis
 on:
-  workflow_dispatch: null
   schedule:
-    - cron: '35 1 * * 1'
+    - cron: '35 1 * * *'
 permissions:
   actions: read
   contents: read

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Init TFLint
         run: tflint --init
       - name: Run TFLint
-        run: tflint --format sarif > tflint.sarif
+        run: tflint --format sarif
       - name: Write output to file
         run: echo "${{ steps.tflint.outputs.stdout }}" > tflint.sarif
       - name: Upload SARIF file

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -17,17 +17,17 @@ jobs:
           - ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           fetch-depth: 0
       - name: Cache plugin dir
-        uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812
+        uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812 # v3.2.5
         with:
           path: ~/.tflint.d/plugins
           key: '${{ matrix.os }}-tflint-${{ hashFiles(''.tflint.hcl'') }}'
       - uses: >-
-          terraform-linters/setup-tflint@ba6bb2989f94daf58a4cc6eac2c1ca7398a678bf
+          terraform-linters/setup-tflint@ba6bb2989f94daf58a4cc6eac2c1ca7398a678bf # v3.0.0
         name: Setup TFLint
         with:
           tflint_version: latest
@@ -37,39 +37,41 @@ jobs:
         run: tflint --format sarif --force > tflint.sarif
       - name: Upload SARIF file
         uses: >-
-          github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5
+          github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4
         with:
           sarif_file: tflint.sarif
+          category: code-scanning
   tfsec:
     name: tfsec
     runs-on: ubuntu-latest
     steps:
       - name: Clone repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           fetch-depth: 0
       - name: Run tfsec
-        uses: aquasecurity/tfsec-action@b466648d6e39e7c75324f25d83891162a721f2d6
+        uses: aquasecurity/tfsec-action@b466648d6e39e7c75324f25d83891162a721f2d6 # v1.0.3
         with:
           additional_args: '--format sarif --out tfsec.sarif'
       - name: Upload SARIF file
         uses: >-
-          github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5
+          github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4
         with:
           sarif_file: tfsec.sarif
+          category: code-scanning
   checkov:
     name: checkov
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           fetch-depth: 0
       - name: Run Checkov action
         id: checkov
-        uses: bridgecrewio/checkov-action@d760887e9ca1a14f871195ab650988ac39c90a0a
+        uses: bridgecrewio/checkov-action@d760887e9ca1a14f871195ab650988ac39c90a0a # v12.2138.0
         with:
           directory: ./
           framework: terraform
@@ -77,6 +79,7 @@ jobs:
           output_format: sarif
       - name: Upload SARIF file
         uses: >-
-          github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5
+          github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4
         with:
           sarif_file: ./checkov.sarif
+          category: code-scanning

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -33,8 +33,9 @@ jobs:
       - name: Init TFLint
         run: tflint --init
       - name: Run TFLint
-        run: |
-          tflint --format sarif > tflint.sarif
+        run: tflint --format sarif > tflint.sarif
+      - name: Write output to file
+        run: echo "${{ steps.tflint.outputs.stdout }}" > tflint.sarif
       - name: Upload SARIF file
         uses: >-
           github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -7,6 +7,8 @@ permissions:
   actions: read
   contents: read
   security-events: write
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   tflint:
     runs-on: '${{ matrix.os }}'


### PR DESCRIPTION
* Properly set the `cron` schedule to run the workflow nightly at 01:35
* Added to `--force` flag to tflint to prevent workflow failure when errors are found
* Set the `GH_TOKEN` environment variable to reduce incidence of rate limiting