### PR TITLE
Improve code-scanning task

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -1,16 +1,19 @@
 name: Secure Code Analysis
 on:
+  workflow_dispatch:
   schedule:
     - cron: '35 1 * * *'
-permissions:
-  actions: read
-  contents: read
-  security-events: write
 env:
-  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+permissions:
+  contents: read
 jobs:
   tflint:
     runs-on: '${{ matrix.os }}'
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       matrix:
         os:
@@ -33,7 +36,7 @@ jobs:
       - name: Init TFLint
         run: tflint --init
       - name: Run TFLint
-        run: tflint --format sarif --force > tflint.sarif
+        run: tflint --disable_rule=terraform_unused_declarations --format sarif > tflint.sarif
       - name: Upload SARIF file
         if: success() || failure()
         uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4
@@ -42,6 +45,10 @@ jobs:
   tfsec:
     name: tfsec
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - name: Clone repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -51,7 +58,7 @@ jobs:
       - name: Run tfsec
         uses: aquasecurity/tfsec-action@b466648d6e39e7c75324f25d83891162a721f2d6 # v1.0.3
         with:
-          additional_args: '--format sarif --out tfsec.sarif'
+          additional_args: '--format sarif --out tfsec.sarif --exclude aws-ssm-secret-use-customer-key,github-repositories-private,aws-vpc-no-excessive-port-access,github-repositories-require-signed-commits'
       - name: Upload SARIF file
         if: success() || failure()
         uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4
@@ -60,6 +67,10 @@ jobs:
   checkov:
     name: checkov
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
@@ -74,6 +85,7 @@ jobs:
           framework: terraform
           output_file_path: ./checkov.sarif
           output_format: sarif
+          skip_check: CKV_GIT_1,CKV_AWS_126,CKV2_AWS_38,CKV2_AWS_39
       - name: Upload SARIF file
         if: success() || failure()
         uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4


### PR DESCRIPTION
After observation it appears that the `GH_TOKEN` variable needs to be passed in as `GITHUB_TOKEN` to avoid API-based rate limiting. This PR includes a few other fixes around permissions and scan exclusions.

* tightened permissions on a per-job basis
* added common exclusions to scans
* amended GITHUB_TOKEN variable