### PR TITLE
Remove workflow_dispatch

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Init TFLint
         run: tflint --init
       - name: Run TFLint
-        run: tflint --disable_rule=terraform_unused_declarations --format sarif > tflint.sarif
+        run: tflint --disable-rule=terraform_unused_declarations --format sarif > tflint.sarif
       - name: Upload SARIF file
         if: success() || failure()
         uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5 # v2.2.4

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -1,6 +1,5 @@
 name: Secure Code Analysis
 on:
-  workflow_dispatch:
   schedule:
     - cron: '35 1 * * *'
 env:


### PR DESCRIPTION
Now that the updated code-scanning.yml has been successfully tested, it no longer requires the workflow_dispatch statement. The task is to be run on a scheduled basis, therefore the option is manually running the action is not required.