### PR TITLE
Removes the use of tee from unit test workflow.

### DIFF
--- a/.github/workflows/go-terratest.yml
+++ b/.github/workflows/go-terratest.yml
@@ -29,5 +29,5 @@ jobs:
         working-directory: test
         run: |
           chmod 700 ../scripts/redact-output.sh
-          go test -v | tee >(../scripts/redact-output.sh)
+          go test -v | ../scripts/redact-output.sh
           exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Removes the use of tee from the workflow as that was splitting the log output resulting in parts of the workflow log not being redacted.